### PR TITLE
Switch from Net::HTTP to Net::HTTP::Persistent for improved performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gemspec
 
 gem 'minitest'
 gem 'webmock'
+
+gem 'net-http-persistent'

--- a/gabba.gemspec
+++ b/gabba.gemspec
@@ -18,4 +18,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+
+  s.add_dependency  'net-http-persistent', '>=2.5'
 end

--- a/lib/gabba/version.rb
+++ b/lib/gabba/version.rb
@@ -1,5 +1,5 @@
 module Gabba
   unless const_defined?('VERSION')
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
Example use:
ga = Gabba::Gabba.new('UA-12345', 'www.example.com')
events.each {|category, action, label, value| ga.event(category, action, label, value)}
