### PR TITLE
Add support for non-interactive custom events

### DIFF
--- a/README
+++ b/README
@@ -10,3 +10,5 @@ Gabba::Gabba.new("UT-1234", "mydomain.com").page_view("something", "track/me")
 - Track custom events
 Gabba::Gabba.new("UT-1234", "mydomain.com").event("Videos", "Play", "ID", "123")
 
+- Track a non-interactive custom event
+Gabba::Gabba.new("UT-1234", "mydomain.com").event("Videos", "Play", "ID", "123", true)

--- a/lib/gabba/gabba.rb
+++ b/lib/gabba/gabba.rb
@@ -50,16 +50,18 @@ module Gabba
       }
     end
   
-    def event(category, action, label = nil, value = nil, utmhid = random_id)
+    def event(category, action, label = nil, value = nil, utmni = false, utmhid = random_id)
       check_account_params
-      hey(event_params(category, action, label, value, utmhid))
+      hey(event_params(category, action, label, value, utmni, utmhid))
     end
 
-    def event_params(category, action, label = nil, value = nil, utmhid = nil)
+    def event_params(category, action, label = nil, value = nil, utmni = false, utmhid = false)
+      raise ArgumentError.new("utmni must be a boolean") if (utmni.class != TrueClass && utmni.class != FalseClass)
       {
         :utmwv => @utmwv,
         :utmn => @utmn,
         :utmhn => @utmhn,
+        :utmni => (1 if utmni), # 1 for non interactive event, excluded from bounce calcs
         :utmt => 'event',
         :utme => event_data(category, action, label, value),
         :utmcs => @utmcs,

--- a/spec/gabba_spec.rb
+++ b/spec/gabba_spec.rb
@@ -32,7 +32,7 @@ describe Gabba::Gabba do
       @gabba = Gabba::Gabba.new("abc", "123")
       @gabba.utmn = "1009731272"
       @gabba.utmcc = ''
-      stub_analytics @gabba.event_params("cat1", "act1", "lab1", "val1", "6783939397")
+      stub_analytics @gabba.event_params("cat1", "act1", "lab1", "val1", false, "6783939397")
     end
     
     it "must require GA account" do
@@ -52,7 +52,11 @@ describe Gabba::Gabba do
     end
     
     it "must do event request to google" do
-      @gabba.event("cat1", "act1", "lab1", "val1", "6783939397").code.must_equal("200")
+      @gabba.event("cat1", "act1", "lab1", "val1", false, "6783939397").code.must_equal("200")
+    end
+
+    it "must be able to send non interactive events" do
+      @gabba.event("cat1", "act1", "lab1", "val1", true).code.must_equal("200")
     end
 
   end


### PR DESCRIPTION
See http://analytics.blogspot.com/2011/10/non-interaction-events-wait-what.html

This adds support for non-interactive events, which aren't included by Google Analytics when computing page-based metrics like the bounce rate.

We use this at www.apptentive.com to capture data on APIs calls that we don't want appearing as site visits.
