### PR TITLE
Allow passing of the GA cookie utmz for better tracking

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,8 +23,8 @@ Gabba::Gabba.new("UT-1234", "mydomain.com").event("Videos", "Play", "ID", "123",
 ```ruby
 gabba = Gabba::Gabba.new("UT-1234", "mydomain.com")
 
-# grab the __utma unique identifier
-gabba.identify_user(cookies[:__utma])
+# grab the __utma and (optionally) __utmz unique identifiers
+gabba.identify_user(cookies[:__utma], cookies[:__utmz])
 
 # trigger actions as normal
 gabba.page_view("something", "track/me")

--- a/lib/gabba/gabba.rb
+++ b/lib/gabba/gabba.rb
@@ -22,7 +22,7 @@ module Gabba
 
     ESCAPES = %w{ ' ! * ) }
 
-    attr_accessor :utmwv, :utmn, :utmhn, :utmcs, :utmul, :utmdt, :utmp, :utmac, :utmt, :utmcc, :user_agent, :utma
+    attr_accessor :utmwv, :utmn, :utmhn, :utmcs, :utmul, :utmdt, :utmp, :utmac, :utmt, :utmcc, :user_agent, :utma, :utmz
 
     # Public: Initialize Gabba Google Analytics Tracking Object.
     #
@@ -279,24 +279,26 @@ module Gabba
       }
     end
 
-    # Public: provide the user's __utma attribute from analytics cookie, allowing
+    # Public: provide the user's __utma and __utmz attributes from analytics cookie, allowing
     # better tracking of user flows
     #
     # Called before page_view etc
     #
     # Examples:
     #   g = Gabba::Gabba.new("UT-1234", "mydomain.com")
-    #   g.identify_user(cookies[:__utma])
+    #   g.identify_user(cookies[:__utma], cookies[:__utmz])
     #   g.page_view("something", "track/me")
     #
-    def identify_user(utma)
+    def identify_user(utma, utmz=nil)
       @utma = utma
+      @utmz = utmz
     end
 
     # create magical cookie params used by GA for its own nefarious purposes
     def cookie_params(utma1 = random_id, utma2 = rand(1147483647) + 1000000000, today = Time.now)
       @utma ||= "1.#{utma1}00145214523.#{utma2}.#{today.to_i}.#{today.to_i}.15"
-      "__utma=#{@utma};+__utmz=1.#{today.to_i}.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none);"
+      @utmz ||= "1.#{today.to_i}.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none)"
+      "__utma=#{@utma};+__utmz=#{@utmz};"
     end
 
     # sanity check that we have needed params to even call GA

--- a/spec/gabba_spec.rb
+++ b/spec/gabba_spec.rb
@@ -113,7 +113,14 @@ describe Gabba::Gabba do
       # This is how the Google cookie is named
       cookies = { :__utma => "long_code"}
       @gabba.identify_user(cookies[:__utma])
-      @gabba.cookie_params.must_match /utma=long_code;/
+      @gabba.cookie_params.must_match(/utma=long_code;/)
+      @gabba.cookie_params.must_match(/utmz=.*direct.*;/)
+    end
+    it "must use the optionally supplied utmz in cookie_params" do
+      cookies = { :__utma => "long_code", :__utmz => "utmz_code" }
+      @gabba.identify_user(cookies[:__utma], cookies[:__utmz])
+      @gabba.cookie_params.must_match(/utma=long_code;/)
+      @gabba.cookie_params.must_match(/utmz=utmz_code;/)
     end
   end
 


### PR DESCRIPTION
The utmz param is optional - existing usages will be unaffected. This fix has helped us identify returning visitors to our app, previously GA was not correlating these visitors as part of an existing session. Might also fix #15.
