### PR TITLE
Add support for setting utmr (referer) and utmip (IP address) parameters

### DIFF
--- a/lib/gabba/gabba.rb
+++ b/lib/gabba/gabba.rb
@@ -46,7 +46,7 @@ module Gabba
 
       @utmac = ga_acct
       @utmhn = domain
-      @user_agent = agent || Gabba::USER_AGENT
+      @user_agent =  (agent && agent.length > 0) ? agent : Gabba::USER_AGENT
 
       @custom_vars = []
     end
@@ -185,7 +185,9 @@ module Gabba
         :utmul => @utmul,
         :utmhid => utmhid,
         :utmac => @utmac,
-        :utmcc => @utmcc || cookie_params
+        :utmcc => @utmcc || cookie_params,
+        :utmr => @utmr,
+        :utmip => @utmip
       }
     end
 
@@ -243,7 +245,9 @@ module Gabba
         :utmtsp => shipping,
         :utmtci => city,
         :utmtrg => region,
-        :utmtco => country
+        :utmtco => country,
+        :utmr => @utmr,
+        :utmip => @utmip
       }
     end
 
@@ -278,7 +282,9 @@ module Gabba
         :utmipn => name,
         :utmiva => category,
         :utmipr => price,
-        :utmiqt => quantity
+        :utmiqt => quantity,
+        :utmr => @utmr,
+        :utmip => @utmip
       }
     end
 

--- a/lib/gabba/gabba.rb
+++ b/lib/gabba/gabba.rb
@@ -46,7 +46,7 @@ module Gabba
 
       @utmac = ga_acct
       @utmhn = domain
-      @user_agent = agent
+      @user_agent = agent || Gabba::USER_AGENT
 
       @custom_vars = []
     end

--- a/lib/gabba/gabba.rb
+++ b/lib/gabba/gabba.rb
@@ -1,6 +1,7 @@
 # yo, easy server-side tracking for Google Analytics... hey!
-require "uri"
-require "net/http"
+require 'uri'
+require 'net/http'
+require 'ipaddr'
 require 'cgi'
 require File.dirname(__FILE__) + '/version'
 
@@ -22,7 +23,7 @@ module Gabba
 
     ESCAPES = %w{ ' ! * ) }
 
-    attr_accessor :utmwv, :utmn, :utmhn, :utmcs, :utmul, :utmdt, :utmp, :utmac, :utmt, :utmcc, :user_agent, :utma, :utmz
+    attr_accessor :utmwv, :utmn, :utmhn, :utmcs, :utmul, :utmdt, :utmp, :utmac, :utmt, :utmcc, :user_agent, :utma, :utmz, :utmr, :utmip
 
     # Public: Initialize Gabba Google Analytics Tracking Object.
     #
@@ -137,7 +138,9 @@ module Gabba
         :utmhid => utmhid,
         :utmp => page,
         :utmac => @utmac,
-        :utmcc => @utmcc || cookie_params
+        :utmcc => @utmcc || cookie_params,
+        :utmr => @utmr,
+        :utmip => @utmip
       }
 
       # Add custom vars if present
@@ -292,6 +295,35 @@ module Gabba
     def identify_user(utma, utmz=nil)
       @utma = utma
       @utmz = utmz
+      self
+    end
+
+    # Public: provide the referer attribute, allowing for referral tracking
+    #
+    # Called before page_view etc
+    #
+    # Examples:
+    #   g = Gabba::Gabba.new("UT-1234", "mydomain.com")
+    #   g.referer(request.env['HTTP_REFERER'])
+    #   g.page_view("something", "track/me")
+    #
+    def referer(utmr)
+      @utmr = utmr
+      self
+    end
+
+    # Public: provide the referer attribute, allowing for IP address tracking
+    #
+    # Called before page_view etc
+    #
+    # Examples:
+    #   g = Gabba::Gabba.new("UT-1234", "mydomain.com")
+    #   g.ip(request.env["REMOTE_ADDR"])
+    #   g.page_view("something", "track/me")
+    #
+    def ip(utmip)
+      @utmip = ::IPAddr.new(utmip).mask(24).to_s
+      self
     end
 
     # create magical cookie params used by GA for its own nefarious purposes

--- a/lib/gabba/gabba.rb
+++ b/lib/gabba/gabba.rb
@@ -298,7 +298,7 @@ module Gabba
       self
     end
 
-    # Public: provide the referer attribute, allowing for referral tracking
+    # Public: provide the utmr attribute, allowing for referral tracking
     #
     # Called before page_view etc
     #
@@ -312,7 +312,7 @@ module Gabba
       self
     end
 
-    # Public: provide the referer attribute, allowing for IP address tracking
+    # Public: provide the utmip attribute, allowing for IP address tracking
     #
     # Called before page_view etc
     #

--- a/spec/gabba_spec.rb
+++ b/spec/gabba_spec.rb
@@ -25,6 +25,18 @@ describe Gabba::Gabba do
     it "must do page view request to google" do
       @gabba.page_view("title", "/page/path", "6783939397").code.must_equal("200")
     end
+
+    it "should use Gabba user agent if none is specified" do
+      @gabba.user_agent.must_equal(Gabba::Gabba::USER_AGENT)
+    end
+
+    it "should use Gabba user agent if nil is specified" do
+      Gabba::Gabba.new("abc","123",nil).user_agent.must_equal(Gabba::Gabba::USER_AGENT)
+    end
+
+    it "should use Gabba user agent if blank is specified" do
+      Gabba::Gabba.new("abc","123","").user_agent.must_equal(Gabba::Gabba::USER_AGENT)
+    end
   end
 
   describe "when tracking custom events" do
@@ -121,6 +133,47 @@ describe Gabba::Gabba do
       @gabba.identify_user(cookies[:__utma], cookies[:__utmz])
       @gabba.cookie_params.must_match(/utma=long_code;/)
       @gabba.cookie_params.must_match(/utmz=utmz_code;/)
+    end
+  end
+
+  describe "when using referer" do
+    referer = "http://www.someurl.com/blah/blah"
+    before do
+      @gabba = Gabba::Gabba.new("abc", "123")
+      @gabba.referer(referer)
+    end
+    it "must use the specified referer in page_view_params" do
+      @gabba.page_view_params("whocares","doesntmatter")[:utmr].must_equal(referer)
+    end
+    it "must use the specified referer in event_params" do
+      @gabba.event_params("whocares","doesntmatter")[:utmr].must_equal(referer)
+    end
+    it "must use the specified referer in transaction_params" do
+      @gabba.transaction_params('order_id', 'total', 'store_name', 'tax', 'shipping', 'city', 'region', 'country', 'utmhid')[:utmr].must_equal(referer)
+    end
+    it "must use the specified referer in item_params" do
+      @gabba.item_params('order_id', 'item_sku', 'name', 'category', 'price', 'quantity', 'utmhid')[:utmr].must_equal(referer)
+    end
+  end
+
+  describe "when using ip" do
+    ip = "123.123.123.123"
+    masked_ip = "123.123.123.0"
+    before do
+      @gabba = Gabba::Gabba.new("abc", "123")
+      @gabba.ip(ip)
+    end
+    it "must use the specified referer in page_view_params" do
+      @gabba.page_view_params("whocares","doesntmatter")[:utmip].must_equal(masked_ip)
+    end
+    it "must use the specified referer in event_params" do
+      @gabba.event_params("whocares","doesntmatter")[:utmip].must_equal(masked_ip)
+    end
+    it "must use the specified referer in transaction_params" do
+      @gabba.transaction_params('order_id', 'total', 'store_name', 'tax', 'shipping', 'city', 'region', 'country', 'utmhid')[:utmip].must_equal(masked_ip)
+    end
+    it "must use the specified referer in item_params" do
+      @gabba.item_params('order_id', 'item_sku', 'name', 'category', 'price', 'quantity', 'utmhid')[:utmip].must_equal(masked_ip)
     end
   end
 


### PR DESCRIPTION
I've added two methods referer(utmr) and ip(utmip) to allow setting the referer and IP address for page view requests. The ip method automatically masks the last octet to anonymize the IP address.

Should these parameters be sent with events or any of the other supported requests? Currently I've only added them to page_view.
