### PR TITLE
Make GitHub repo discoverable from rubygems.org

### DIFF
--- a/gabba.gemspec
+++ b/gabba.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Ron Evans"]
   s.email       = ["ron dot evans at gmail dot com"]
-  s.homepage    = ""
+  s.homepage    = "https://github.com/hybridgroup/gabba"
   s.summary     = %q{Easy server-side tracking for Google Analytics}
   s.description = %q{Easy server-side tracking for Google Analytics}
 


### PR DESCRIPTION
Tiny thing here, but I use a browser quick search to land at Rubygems pages all the time these days as a portal to find GitHub repos, rdoc.info links, etc. It irks me when I land on those pages and have to make another search elsewhere to find the repo :smile: 
