### PR TITLE
Add support for Yo::Gabba::Gabba

### DIFF
--- a/lib/gabba/gabba.rb
+++ b/lib/gabba/gabba.rb
@@ -375,3 +375,6 @@ module Gabba
   end # Gabba Class
 
 end
+
+# Allow for Yo::Gabba::Gabba
+module Yo ; Gabba = ::Gabba ; end

--- a/spec/gabba_spec.rb
+++ b/spec/gabba_spec.rb
@@ -238,6 +238,16 @@ describe Gabba::Gabba do
     end
   end
 
+  describe 'Yo::Gabba::Gabba' do
+    before do
+      @gabba = Yo::Gabba::Gabba.new('abc', '123')
+    end
+
+    it 'must be aliased to Gabba::Gabba' do
+      @gabba.must_be_instance_of Gabba::Gabba
+    end
+  end
+
   def stub_analytics(expected_params)
     s = stub_request(:get, /www.google-analytics.com\/__utm.gif\?utmac=#{expected_params[:utmac]}&.*/).
           to_return(:status => 200, :body => "", :headers => {})


### PR DESCRIPTION
This addresses https://github.com/hybridgroup/gabba/issues/24.

Can either do it this way, as an alias, or restructure so that `Yo` is the actual root module and `Yo::Gabba::Gabba` is the preferred way to create a new instance.

Example code:

``` ruby
@gabba = Yo::Gabba::Gabba.new 'abc', '123'
#=> #<Gabba::Gabba:0x007f8efb282468 [...]>
```
