### PR TITLE
fix 'uninitialized constant Gabba::Gabba::VERSION' exception

### DIFF
--- a/lib/gabba.rb
+++ b/lib/gabba.rb
@@ -1,2 +1,2 @@
-require 'gabba/gabba'
 require 'gabba/version'
+require 'gabba/gabba'


### PR DESCRIPTION
Otherwise I get something like this 

`lib/gabba/gabba.rb:17:in `<class:Gabba>': uninitialized constant Gabba::Gabba::VERSION (NameError)`

ENV:
ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin12.3.0]
rails 4.0
